### PR TITLE
Replace `emotes.awoo.nl` with `chatvau.lt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Dankerino
+
+- Minor: Replace `emotes.awoo.nl` with `chatvau.lt`. (#147)
+
 ## Unversioned
 
 ## 2.5.4-beta.1

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -468,8 +468,7 @@ EmotePtr TwitchEmotes::getOrCreateEmote(const EmoteId &id,
                                baseSize * (1.0 / emote3xScaleFactor)),
             },
             Tooltip{name.toHtmlEscaped() + "<br>Twitch Emote"},
-            Url{QString("https://emotes.awoo.nl/twitch/emote/%1")
-                    .arg(id.string)},
+            Url{QString("https://chatvau.lt/emote/twitch/%1").arg(id.string)},
         });
     }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -131,7 +131,7 @@ void addEmoteContextMenuItems(QMenu *menu, const Emote &emote,
     };
     if (creatorFlags.has(MessageElementFlag::TwitchEmote))
     {
-        addPageLink("RaccAttack");
+        addPageLink("ChatVault");
     }
     else if (creatorFlags.has(MessageElementFlag::BttvEmote))
     {

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -158,7 +158,7 @@ AboutPage::AboutPage()
             l.emplace<QLabel>("Emoji datasource provided by <a href=\"https://www.iamcal.com/\">Cal Henderson</a> "
                               "(<a href=\"https://github.com/iamcal/emoji-data/blob/master/LICENSE\">show license</a>)")->setOpenExternalLinks(true);
             l.emplace<QLabel>("GraphQL Logo is licensed under <a href=\"https://github.com/graphql/graphql-spec/issues/398#issuecomment-426844088\">CC-BY-4.0</a>")->setOpenExternalLinks(true);
-            l.emplace<QLabel>("Twitch emote data provided by <a href=\"https://emotes.awoo.nl/\">emotes.awoo.nl</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("Twitch emote data provided by <a href=\"https://chatvau.lt/\">chatvau.lt</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 

--- a/tests/snapshots/IrcMessageHandler/action.json
+++ b/tests/snapshots/IrcMessageHandler/action.json
@@ -131,6 +131,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emote-emoji.json
+++ b/tests/snapshots/IrcMessageHandler/emote-emoji.json
@@ -132,6 +132,7 @@
                 {
                     "emote": {
                         "images": {
+                            "homePage": "https://chatvau.lt/emote/twitch/25",
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
@@ -168,6 +169,7 @@
                 {
                     "emote": {
                         "images": {
+                            "homePage": "https://chatvau.lt/emote/twitch/25",
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"

--- a/tests/snapshots/IrcMessageHandler/emote.json
+++ b/tests/snapshots/IrcMessageHandler/emote.json
@@ -2,8 +2,7 @@
     "input": "@badge-info=;badges=no_audio/1;color=#DAA520;display-name=Mm2PL;emote-only=1;emotes=1902:0-4;first-msg=0;flags=;id=9b1c3cb9-7817-47ea-add1-f9d4a9b4f846;mod=0;returning-chatter=0;room-id=11148817;subscriber=0;tmi-sent-ts=1662201095690;turbo=0;user-id=117691339;user-type= :mm2pl!mm2pl@mm2pl.tmi.twitch.tv PRIVMSG #pajlada :Keepo",
     "output": [
         {
-            "badgeInfos": {
-            },
+            "badgeInfos": {},
             "badges": [
                 "no_audio"
             ],
@@ -99,6 +98,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1902",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emotes.json
+++ b/tests/snapshots/IrcMessageHandler/emotes.json
@@ -99,6 +99,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
@@ -118,6 +119,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1902",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/2.0",
@@ -137,6 +139,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/305954156",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/emotes2.json
@@ -100,6 +100,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
@@ -228,6 +229,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/305954156",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/2.0",
@@ -267,6 +269,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1902",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/emotes3.json
@@ -98,6 +98,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
@@ -149,6 +150,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/emotes4.json
@@ -79,6 +79,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/84608",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/84608/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/84608/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/emotes5.json
+++ b/tests/snapshots/IrcMessageHandler/emotes5.json
@@ -79,6 +79,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/84609",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/84609/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/84609/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/first-msg.json
+++ b/tests/snapshots/IrcMessageHandler/first-msg.json
@@ -101,6 +101,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/ignore-replace.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-replace.json
@@ -81,6 +81,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/305954156",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/2.0",
@@ -115,6 +116,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
@@ -149,6 +151,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1902",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/2.0",
@@ -189,6 +192,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/mod.json
+++ b/tests/snapshots/IrcMessageHandler/mod.json
@@ -106,6 +106,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/41",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/2.0",
@@ -140,6 +141,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/41",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
+++ b/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
@@ -115,6 +115,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/reply-single.json
+++ b/tests/snapshots/IrcMessageHandler/reply-single.json
@@ -156,6 +156,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/1902",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/reward-bits.json
+++ b/tests/snapshots/IrcMessageHandler/reward-bits.json
@@ -71,6 +71,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/42",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/42/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/42/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -101,6 +101,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
@@ -99,6 +99,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",

--- a/tests/snapshots/IrcMessageHandler/simple.json
+++ b/tests/snapshots/IrcMessageHandler/simple.json
@@ -101,6 +101,7 @@
                 },
                 {
                     "emote": {
+                        "homePage": "https://chatvau.lt/emote/twitch/25",
                         "images": {
                             "1x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0",
                             "2x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",


### PR DESCRIPTION
`emotes.awoo.nl` is no longer hosted, and `chatvau.lt` fulfills the requirement now.

closes #146.